### PR TITLE
Use an invalid url with https protocol for invalid url tests.

### DIFF
--- a/tests/input/credential-context-combo3-fail.json
+++ b/tests/input/credential-context-combo3-fail.json
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "not-a-url/contexts/example/v1"
+    "https ://not-a-url/contexts/example/v1"
   ],
   "type": [
     "VerifiableCredential"

--- a/tests/input/credential-issuer-nonurl-fail.json
+++ b/tests/input/credential-issuer-nonurl-fail.json
@@ -6,7 +6,7 @@
     "VerifiableCredential"
   ],
   "validFrom": "2023-02-26T00:36:23Z",
-  "issuer": "not-a-url/issuer/foo",
+  "issuer": "https ://not-a-url/issuer/foo",
   "credentialSubject": {
     "id": "did:example:subject"
   }

--- a/tests/input/credential-not-url-id-fail.json
+++ b/tests/input/credential-not-url-id-fail.json
@@ -6,7 +6,7 @@
   "type": [
     "VerifiableCredential"
   ],
-  "id": "not-a-url/vcs/343cf54b-2c38-480e-b6e8-7302332eae75",
+  "id": "https ://not-a-url/vcs/343cf54b-2c38-480e-b6e8-7302332eae75",
   "validFrom": "2023-02-22T21:52:06Z",
   "issuer": "did:example:issuer",
   "credentialSubject": {

--- a/tests/input/credential-refresh-non-url-id-fail.json
+++ b/tests/input/credential-refresh-non-url-id-fail.json
@@ -7,7 +7,7 @@
   ],
   "refreshService": {
     "type": "https://example.org/#ExampleTestSuiteRefreshService",
-    "id": "not-a-url/8e96ee84-032d-47b2-8d10-86be56032148"
+    "id": "https ://not-a-url/8e96ee84-032d-47b2-8d10-86be56032148"
   },
   "validFrom": "2023-05-28T18:35:45Z",
   "issuer": "did:example:issuer",

--- a/tests/input/credential-schema-non-url-id-fail.json
+++ b/tests/input/credential-schema-non-url-id-fail.json
@@ -7,7 +7,7 @@
   ],
   "credentialSchema": {
     "type": "https://example.org/#ExampleTestSuiteSchema",
-    "id": "not-a-url.org/cd28a5c0-a3ca-4057-9e18-074769a54fdb"
+    "id": "https ://not-a-url.org/cd28a5c0-a3ca-4057-9e18-074769a54fdb"
   },
   "validFrom": "2023-05-28T18:29:40Z",
   "issuer": "did:example:issuer",

--- a/tests/input/credential-status-nonurl-id-fail.json
+++ b/tests/input/credential-status-nonurl-id-fail.json
@@ -15,6 +15,6 @@
   },
   "credentialStatus": {
     "type": "CredentialStatusList2017",
-    "id": "not-a-url/statusList/4"
+    "id": "https ://not-a-url/statusList/4"
   }
 }

--- a/tests/input/credential-type-mapped-nonurl-fail.json
+++ b/tests/input/credential-type-mapped-nonurl-fail.json
@@ -2,7 +2,7 @@
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
     {
-      "ExampleTestCredential": "not-a-url#ExampleTestCredential"
+      "ExampleTestCredential": "https ://not-a-url#ExampleTestCredential"
     }
   ],
   "type": [


### PR DESCRIPTION
Addresses:

https://github.com/digitalbazaar/vc-data-model-2-test-suite/issues/27

Bug: it turns out between the vocab in the Vc2.0 context and the somewhat liberal way json-ld creates relative urls, our existing `not-a-url` tests were not failing in the way they were intended. This PR updates those tests to use a full invalid url with the `https` protocol. Further issues will need to be made on `json-ld` processors as it looks like what `json-ld` will turn into a relative url is kind of interesting.